### PR TITLE
Support for LDAP servers that do not support the memberOf attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ setup -- just using a template and package resource. We leverage the OpenSSH
 cookbook using a `node.override` for the `authorized_keys_command` and
 `authorized_keys_command_user` variables.
 
+Some LDAP installations require you to bind before searching. For example, Jumpcloud
+operates a user directory-as-a-service and allows users to self-service their
+SSH keys. You will need to provide a BindDN and BindPW in order to connect to
+the JumpCloud LDAP directory. See the documentation in this article for details:
+https://jumpcloud.com/engineering-blog/how-to-connect-your-application-to-ldap/
+
 ## Configuration
 
 Authkeys is configured using a JSON file. By default, it'll look in
@@ -57,6 +63,8 @@ environment variable for testing.
   "LDAPPort": 389,
   "RootCAFile": "",
   "UserAttribute": "",
+  "BindDN": "",
+  "BindPW": ""
 }
 ```
 
@@ -69,6 +77,8 @@ environment variable for testing.
 | `LDAPPort`      | Int    | Port to talk to LDAP on                              | `389`                                |
 | `RootCAFile`    | String | A path to a file full of trusted root CAs [Note 2]   | `/etc/ssl/certs/ca-certificates.crt` |
 | `UserAttribute` | String | LDAP Attribute for a User                            | `uid`                                |
+| `BindDN`        | String | Bind DN for your LDAP server (LDAP service account)  | `uid=U,ou=Users,o=123,dc=jc,dc=com`  |
+| `BindPW`        | String | Password for the LDAP service account                | `password`                           |
 
 ### Notes
 
@@ -93,6 +103,9 @@ too many (>1) entries.
 
 Version 2.1.2 removes some superfluous `os.Exit(1)` calls, since `log.Fatalf`
 does that for you.
+
+Version 2.1.3 added support for using a Bind DN for LDAP services such as 
+Jumpcloud.com that require authentication.
 
 ## Contribution
 

--- a/authkeys.go
+++ b/authkeys.go
@@ -27,6 +27,8 @@ type AuthkeysConfig struct {
 	LDAPPort int
 	RootCAFile string
 	UserAttribute string
+	BindDN string
+	BindPW string
 }
 
 func NewConfig(fname string) AuthkeysConfig {
@@ -104,6 +106,14 @@ func main() {
 	err = l.StartTLS(tlsConfig)
 	if err != nil {
 		log.Fatalf("Unable to start TLS connection: %s", err)
+	}
+
+	// If we have a BindDN go ahead and bind before searching
+	if config.BindDN != "" && config.BindPW != "" {
+		err := l.Bind(config.BindDN, config.BindPW)
+		if err != nil {
+			log.Fatalf("Unable to bind: %s", err)
+		}
 	}
 
 	// Set up an LDAP search and actually do the search

--- a/authkeys.go
+++ b/authkeys.go
@@ -165,6 +165,7 @@ func main() {
 	var attribute string
 	cn := "cn="
 	if listUsers {
+	var Users []User
 		for _, entry := range sr.Entries {
 			rawMemberOf := entry.GetAttributeValues("memberOf")
 			var memberOf []string
@@ -173,17 +174,18 @@ func main() {
 				termLoc := strings.Index(rawMemberOf[group], ",")
 				memberOf = append(memberOf, rawMemberOf[group][cnLoc+len(cn):termLoc])
 			}
-			user, err := json.Marshal(User{
+			Users = append(Users,User{
 				Uid: string(entry.GetAttributeValue("uid")),
 				UidNumber: string(entry.GetAttributeValue("uidNumber")),
 				MemberOf: memberOf,
 				HomeDirectory: string(entry.GetAttributeValue("homeDirectory")),
 			})
-			if err != nil {
-				log.Fatal(err)
-			}
-			fmt.Printf("%s\n", user)
 		}
+		myUsers, err := json.Marshal(Users)
+		if err != nil {
+			log.Fatal(err)
+		}
+	        fmt.Printf("%s\n", myUsers)
 	} else {
 		attribute = config.KeyAttribute
 		for _, entry := range sr.Entries {


### PR DESCRIPTION
Some LDAP implementations do not support returning the `memberOf` list of groups such as Okta.